### PR TITLE
Removing crossOrigin for compatibility with three 0.74

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19,16 +19,10 @@ module.exports = function (THREE) {
       var scope = this;
 
       var loader = new THREE.XHRLoader(scope.manager);
-      loader.setCrossOrigin(this.crossOrigin);
       loader.load(url, function (text) {
 
         onLoad(scope.parse(text));
       }, onProgress, onError);
-    },
-
-    setCrossOrigin: function setCrossOrigin(value) {
-
-      this.crossOrigin = value;
     },
 
     parse: function parse(text) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-obj-loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NodeJS wrapper for Three.js' OBJLoader function",
   "main": "dist/index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "jshint-stylish": "^2.1.0",
     "remap-istanbul": "^0.4.0",
     "source-map-support": "^0.3.3",
-    "three": "^0.73.0"
+    "three": ">=0.73.0"
   },
   "dependencies": {}
 }

--- a/source/index.js
+++ b/source/index.js
@@ -20,18 +20,11 @@ module.exports = function (THREE) {
       var scope = this;
 
       var loader = new THREE.XHRLoader(scope.manager);
-      loader.setCrossOrigin(this.crossOrigin);
       loader.load(url, function (text) {
 
         onLoad(scope.parse(text));
 
       }, onProgress, onError);
-
-    },
-
-    setCrossOrigin: function (value) {
-
-      this.crossOrigin = value;
 
     },
 


### PR DESCRIPTION
Addresses issue #3

The loader API was volatile-ly changed in three@0.74 because of this ticket:
https://github.com/mrdoob/three.js/issues/7568

The related commit:
https://github.com/mrdoob/three.js/commit/a88a3e62d73b5964f57899eb60d5fd9291bae1f4#diff-b04ba7bf9d62701ef06636159e4a75d9L30

The commit to this repo just ports that change over. It also changes the
semver for threejs to include versions above the current one (which
includes 0.74)
