### PR TITLE
Use .flatShading instead of deprecated .shading

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -715,7 +715,7 @@ module.exports = function (THREE) {
 
           }
 
-          material.shading = sourceMaterial.smooth ? THREE.SmoothShading : THREE.FlatShading;
+          material.flatShading = sourceMaterial.smooth ? false : true;
 
           createdMaterials.push(material);
 


### PR DESCRIPTION
I get deprecation warnings for every object I load without this.

See https://github.com/mrdoob/three.js/commit/ff4d488d790c988ac3f93295d56828535c4f20a8#diff-c95aa6af1ef517957bfbff6af39992f5L699