### PR TITLE
Update OBJLoader

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -10,751 +10,715 @@ module.exports = function (THREE) {
    * @author mrdoob / http://mrdoob.com/
    */
 
-  THREE.OBJLoader = function (manager) {
+	THREE.OBJLoader = ( function () {
 
-    this.manager = (manager !== undefined) ? manager : THREE.DefaultLoadingManager;
+		// o object_name | g group_name
+		var object_pattern = /^[og]\s*(.+)?/;
+		// mtllib file_reference
+		var material_library_pattern = /^mtllib /;
+		// usemtl material_name
+		var material_use_pattern = /^usemtl /;
 
-    this.materials = null;
+		function ParserState() {
 
-    this.regexp = {
-      // v float float float
-      vertex_pattern: /^v\s+([\d|\.|\+|\-|e|E]+)\s+([\d|\.|\+|\-|e|E]+)\s+([\d|\.|\+|\-|e|E]+)/,
-      // vn float float float
-      normal_pattern: /^vn\s+([\d|\.|\+|\-|e|E]+)\s+([\d|\.|\+|\-|e|E]+)\s+([\d|\.|\+|\-|e|E]+)/,
-      // vt float float
-      uv_pattern: /^vt\s+([\d|\.|\+|\-|e|E]+)\s+([\d|\.|\+|\-|e|E]+)/,
-      // f vertex vertex vertex
-      face_vertex: /^f\s+(-?\d+)\s+(-?\d+)\s+(-?\d+)(?:\s+(-?\d+))?/,
-      // f vertex/uv vertex/uv vertex/uv
-      face_vertex_uv: /^f\s+(-?\d+)\/(-?\d+)\s+(-?\d+)\/(-?\d+)\s+(-?\d+)\/(-?\d+)(?:\s+(-?\d+)\/(-?\d+))?/,
-      // f vertex/uv/normal vertex/uv/normal vertex/uv/normal
-      face_vertex_uv_normal: /^f\s+(-?\d+)\/(-?\d+)\/(-?\d+)\s+(-?\d+)\/(-?\d+)\/(-?\d+)\s+(-?\d+)\/(-?\d+)\/(-?\d+)(?:\s+(-?\d+)\/(-?\d+)\/(-?\d+))?/,
-      // f vertex//normal vertex//normal vertex//normal
-      face_vertex_normal: /^f\s+(-?\d+)\/\/(-?\d+)\s+(-?\d+)\/\/(-?\d+)\s+(-?\d+)\/\/(-?\d+)(?:\s+(-?\d+)\/\/(-?\d+))?/,
-      // o object_name | g group_name
-      object_pattern: /^[og]\s*(.+)?/,
-      // s boolean
-      smoothing_pattern: /^s\s+(\d+|on|off)/,
-      // mtllib file_reference
-      material_library_pattern: /^mtllib /,
-      // usemtl material_name
-      material_use_pattern: /^usemtl /
-    };
+			var state = {
+				objects: [],
+				object: {},
 
-  };
+				vertices: [],
+				normals: [],
+				colors: [],
+				uvs: [],
 
-  THREE.OBJLoader.prototype = {
+				materialLibraries: [],
 
-    constructor: THREE.OBJLoader,
+				startObject: function ( name, fromDeclaration ) {
 
-    load: function (url, onLoad, onProgress, onError) {
+					// If the current object (initial from reset) is not from a g/o declaration in the parsed
+					// file. We need to use it for the first parsed g/o to keep things in sync.
+					if ( this.object && this.object.fromDeclaration === false ) {
 
-      var scope = this;
-      this.onError = onError || defaultOnError;
+						this.object.name = name;
+						this.object.fromDeclaration = ( fromDeclaration !== false );
+						return;
 
-      var loader = new THREE.FileLoader(scope.manager);
-      loader.setPath(this.path);
-      loader.load(url, function (text) {
+					}
 
-        onLoad(scope.parse(text));
+					var previousMaterial = ( this.object && typeof this.object.currentMaterial === 'function' ? this.object.currentMaterial() : undefined );
 
-      }, onProgress, onError);
+					if ( this.object && typeof this.object._finalize === 'function' ) {
 
-    },
+						this.object._finalize( true );
 
-    setPath: function (value) {
+					}
 
-      this.path = value;
+					this.object = {
+						name: name || '',
+						fromDeclaration: ( fromDeclaration !== false ),
 
-    },
+						geometry: {
+							vertices: [],
+							normals: [],
+							colors: [],
+							uvs: []
+						},
+						materials: [],
+						smooth: true,
 
-    setMaterials: function (materials) {
+						startMaterial: function ( name, libraries ) {
 
-      this.materials = materials;
+							var previous = this._finalize( false );
 
-    },
+							// New usemtl declaration overwrites an inherited material, except if faces were declared
+							// after the material, then it must be preserved for proper MultiMaterial continuation.
+							if ( previous && ( previous.inherited || previous.groupCount <= 0 ) ) {
 
-    _createParserState: function () {
+								this.materials.splice( previous.index, 1 );
 
-      var state = {
-        objects: [],
-        object: {},
+							}
 
-        vertices: [],
-        normals: [],
-        uvs: [],
+							var material = {
+								index: this.materials.length,
+								name: name || '',
+								mtllib: ( Array.isArray( libraries ) && libraries.length > 0 ? libraries[ libraries.length - 1 ] : '' ),
+								smooth: ( previous !== undefined ? previous.smooth : this.smooth ),
+								groupStart: ( previous !== undefined ? previous.groupEnd : 0 ),
+								groupEnd: - 1,
+								groupCount: - 1,
+								inherited: false,
 
-        materialLibraries: [],
+								clone: function ( index ) {
 
-        startObject: function (name, fromDeclaration) {
+									var cloned = {
+										index: ( typeof index === 'number' ? index : this.index ),
+										name: this.name,
+										mtllib: this.mtllib,
+										smooth: this.smooth,
+										groupStart: 0,
+										groupEnd: - 1,
+										groupCount: - 1,
+										inherited: false
+									};
+									cloned.clone = this.clone.bind( cloned );
+									return cloned;
 
-          // If the current object (initial from reset) is not from a g/o declaration in the parsed
-          // file. We need to use it for the first parsed g/o to keep things in sync.
-          if (this.object && this.object.fromDeclaration === false) {
+								}
+							};
 
-            this.object.name = name;
-            this.object.fromDeclaration = (fromDeclaration !== false);
-            return;
+							this.materials.push( material );
 
-          }
+							return material;
 
-          var previousMaterial = (this.object && typeof this.object.currentMaterial === 'function' ? this.object.currentMaterial() : undefined);
+						},
 
-          if (this.object && typeof this.object._finalize === 'function') {
+						currentMaterial: function () {
 
-            this.object._finalize(true);
+							if ( this.materials.length > 0 ) {
 
-          }
+								return this.materials[ this.materials.length - 1 ];
 
-          this.object = {
-            name: name || '',
-            fromDeclaration: (fromDeclaration !== false),
+							}
 
-            geometry: {
-              vertices: [],
-              normals: [],
-              uvs: []
-            },
-            materials: [],
-            smooth: true,
+							return undefined;
 
-            startMaterial: function (name, libraries) {
+						},
 
-              var previous = this._finalize(false);
+						_finalize: function ( end ) {
 
-              // New usemtl declaration overwrites an inherited material, except if faces were declared
-              // after the material, then it must be preserved for proper MultiMaterial continuation.
-              if (previous && (previous.inherited || previous.groupCount <= 0)) {
+							var lastMultiMaterial = this.currentMaterial();
+							if ( lastMultiMaterial && lastMultiMaterial.groupEnd === - 1 ) {
 
-                this.materials.splice(previous.index, 1);
+								lastMultiMaterial.groupEnd = this.geometry.vertices.length / 3;
+								lastMultiMaterial.groupCount = lastMultiMaterial.groupEnd - lastMultiMaterial.groupStart;
+								lastMultiMaterial.inherited = false;
 
-              }
+							}
 
-              var material = {
-                index: this.materials.length,
-                name: name || '',
-                mtllib: (Array.isArray(libraries) && libraries.length > 0 ? libraries[libraries.length - 1] : ''),
-                smooth: (previous !== undefined ? previous.smooth : this.smooth),
-                groupStart: (previous !== undefined ? previous.groupEnd : 0),
-                groupEnd: -1,
-                groupCount: -1,
-                inherited: false,
+							// Ignore objects tail materials if no face declarations followed them before a new o/g started.
+							if ( end && this.materials.length > 1 ) {
 
-                clone: function (index) {
-                  var cloned = {
-                    index: (typeof index === 'number' ? index : this.index),
-                    name: this.name,
-                    mtllib: this.mtllib,
-                    smooth: this.smooth,
-                    groupStart: 0,
-                    groupEnd: -1,
-                    groupCount: -1,
-                    inherited: false
-                  };
-                  cloned.clone = this.clone.bind(cloned);
-                  return cloned;
-                }
-              };
+								for ( var mi = this.materials.length - 1; mi >= 0; mi -- ) {
 
-              this.materials.push(material);
+									if ( this.materials[ mi ].groupCount <= 0 ) {
 
-              return material;
+										this.materials.splice( mi, 1 );
 
-            },
+									}
 
-            currentMaterial: function () {
+								}
 
-              if (this.materials.length > 0) {
-                return this.materials[this.materials.length - 1];
-              }
+							}
 
-              return undefined;
+							// Guarantee at least one empty material, this makes the creation later more straight forward.
+							if ( end && this.materials.length === 0 ) {
 
-            },
+								this.materials.push( {
+									name: '',
+									smooth: this.smooth
+								} );
 
-            _finalize: function (end) {
+							}
 
-              var lastMultiMaterial = this.currentMaterial();
-              if (lastMultiMaterial && lastMultiMaterial.groupEnd === -1) {
+							return lastMultiMaterial;
 
-                lastMultiMaterial.groupEnd = this.geometry.vertices.length / 3;
-                lastMultiMaterial.groupCount = lastMultiMaterial.groupEnd - lastMultiMaterial.groupStart;
-                lastMultiMaterial.inherited = false;
+						}
+					};
 
-              }
+					// Inherit previous objects material.
+					// Spec tells us that a declared material must be set to all objects until a new material is declared.
+					// If a usemtl declaration is encountered while this new object is being parsed, it will
+					// overwrite the inherited material. Exception being that there was already face declarations
+					// to the inherited material, then it will be preserved for proper MultiMaterial continuation.
 
-              // Ignore objects tail materials if no face declarations followed them before a new o/g started.
-              if (end && this.materials.length > 1) {
+					if ( previousMaterial && previousMaterial.name && typeof previousMaterial.clone === 'function' ) {
 
-                for (var mi = this.materials.length - 1; mi >= 0; mi--) {
-                  if (this.materials[mi].groupCount <= 0) {
-                    this.materials.splice(mi, 1);
-                  }
-                }
+						var declared = previousMaterial.clone( 0 );
+						declared.inherited = true;
+						this.object.materials.push( declared );
 
-              }
+					}
 
-              // Guarantee at least one empty material, this makes the creation later more straight forward.
-              if (end && this.materials.length === 0) {
+					this.objects.push( this.object );
 
-                this.materials.push({
-                  name: '',
-                  smooth: this.smooth
-                });
+				},
 
-              }
+				finalize: function () {
 
-              return lastMultiMaterial;
+					if ( this.object && typeof this.object._finalize === 'function' ) {
 
-            }
-          };
+						this.object._finalize( true );
 
-          // Inherit previous objects material.
-          // Spec tells us that a declared material must be set to all objects until a new material is declared.
-          // If a usemtl declaration is encountered while this new object is being parsed, it will
-          // overwrite the inherited material. Exception being that there was already face declarations
-          // to the inherited material, then it will be preserved for proper MultiMaterial continuation.
+					}
 
-          if (previousMaterial && previousMaterial.name && typeof previousMaterial.clone === "function") {
+				},
 
-            var declared = previousMaterial.clone(0);
-            declared.inherited = true;
-            this.object.materials.push(declared);
+				parseVertexIndex: function ( value, len ) {
 
-          }
+					var index = parseInt( value, 10 );
+					return ( index >= 0 ? index - 1 : index + len / 3 ) * 3;
 
-          this.objects.push(this.object);
+				},
 
-        },
+				parseNormalIndex: function ( value, len ) {
 
-        finalize: function () {
+					var index = parseInt( value, 10 );
+					return ( index >= 0 ? index - 1 : index + len / 3 ) * 3;
 
-          if (this.object && typeof this.object._finalize === 'function') {
+				},
 
-            this.object._finalize(true);
+				parseUVIndex: function ( value, len ) {
 
-          }
+					var index = parseInt( value, 10 );
+					return ( index >= 0 ? index - 1 : index + len / 2 ) * 2;
 
-        },
+				},
 
-        parseVertexIndex: function (value, len) {
+				addVertex: function ( a, b, c ) {
 
-          var index = parseInt(value, 10);
-          return (index >= 0 ? index - 1 : index + len / 3) * 3;
+					var src = this.vertices;
+					var dst = this.object.geometry.vertices;
 
-        },
+					dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
+					dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
+					dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
 
-        parseNormalIndex: function (value, len) {
+				},
 
-          var index = parseInt(value, 10);
-          return (index >= 0 ? index - 1 : index + len / 3) * 3;
+				addVertexLine: function ( a ) {
 
-        },
+					var src = this.vertices;
+					var dst = this.object.geometry.vertices;
 
-        parseUVIndex: function (value, len) {
+					dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
 
-          var index = parseInt(value, 10);
-          return (index >= 0 ? index - 1 : index + len / 2) * 2;
+				},
 
-        },
+				addNormal: function ( a, b, c ) {
 
-        addVertex: function (a, b, c) {
+					var src = this.normals;
+					var dst = this.object.geometry.normals;
 
-          var src = this.vertices;
-          var dst = this.object.geometry.vertices;
+					dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
+					dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
+					dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
 
-          dst.push(src[a + 0]);
-          dst.push(src[a + 1]);
-          dst.push(src[a + 2]);
-          dst.push(src[b + 0]);
-          dst.push(src[b + 1]);
-          dst.push(src[b + 2]);
-          dst.push(src[c + 0]);
-          dst.push(src[c + 1]);
-          dst.push(src[c + 2]);
+				},
 
-        },
+				addColor: function ( a, b, c ) {
 
-        addVertexLine: function (a) {
+					var src = this.colors;
+					var dst = this.object.geometry.colors;
 
-          var src = this.vertices;
-          var dst = this.object.geometry.vertices;
+					dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
+					dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
+					dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
 
-          dst.push(src[a + 0]);
-          dst.push(src[a + 1]);
-          dst.push(src[a + 2]);
+				},
 
-        },
+				addUV: function ( a, b, c ) {
 
-        addNormal: function (a, b, c) {
+					var src = this.uvs;
+					var dst = this.object.geometry.uvs;
 
-          var src = this.normals;
-          var dst = this.object.geometry.normals;
+					dst.push( src[ a + 0 ], src[ a + 1 ] );
+					dst.push( src[ b + 0 ], src[ b + 1 ] );
+					dst.push( src[ c + 0 ], src[ c + 1 ] );
 
-          dst.push(src[a + 0]);
-          dst.push(src[a + 1]);
-          dst.push(src[a + 2]);
-          dst.push(src[b + 0]);
-          dst.push(src[b + 1]);
-          dst.push(src[b + 2]);
-          dst.push(src[c + 0]);
-          dst.push(src[c + 1]);
-          dst.push(src[c + 2]);
+				},
 
-        },
+				addUVLine: function ( a ) {
 
-        addUV: function (a, b, c) {
+					var src = this.uvs;
+					var dst = this.object.geometry.uvs;
 
-          var src = this.uvs;
-          var dst = this.object.geometry.uvs;
+					dst.push( src[ a + 0 ], src[ a + 1 ] );
 
-          dst.push(src[a + 0]);
-          dst.push(src[a + 1]);
-          dst.push(src[b + 0]);
-          dst.push(src[b + 1]);
-          dst.push(src[c + 0]);
-          dst.push(src[c + 1]);
+				},
 
-        },
+				addFace: function ( a, b, c, ua, ub, uc, na, nb, nc ) {
 
-        addUVLine: function (a) {
+					var vLen = this.vertices.length;
 
-          var src = this.uvs;
-          var dst = this.object.geometry.uvs;
+					var ia = this.parseVertexIndex( a, vLen );
+					var ib = this.parseVertexIndex( b, vLen );
+					var ic = this.parseVertexIndex( c, vLen );
 
-          dst.push(src[a + 0]);
-          dst.push(src[a + 1]);
+					this.addVertex( ia, ib, ic );
 
-        },
+					if ( ua !== undefined ) {
 
-        addFace: function (a, b, c, d, ua, ub, uc, ud, na, nb, nc, nd) {
+						var uvLen = this.uvs.length;
 
-          var vLen = this.vertices.length;
+						ia = this.parseUVIndex( ua, uvLen );
+						ib = this.parseUVIndex( ub, uvLen );
+						ic = this.parseUVIndex( uc, uvLen );
 
-          var ia = this.parseVertexIndex(a, vLen);
-          var ib = this.parseVertexIndex(b, vLen);
-          var ic = this.parseVertexIndex(c, vLen);
-          var id;
+						this.addUV( ia, ib, ic );
 
-          if (d === undefined) {
+					}
 
-            this.addVertex(ia, ib, ic);
+					if ( na !== undefined ) {
 
-          } else {
+						// Normals are many times the same. If so, skip function call and parseInt.
+						var nLen = this.normals.length;
+						ia = this.parseNormalIndex( na, nLen );
 
-            id = this.parseVertexIndex(d, vLen);
+						ib = na === nb ? ia : this.parseNormalIndex( nb, nLen );
+						ic = na === nc ? ia : this.parseNormalIndex( nc, nLen );
 
-            this.addVertex(ia, ib, id);
-            this.addVertex(ib, ic, id);
+						this.addNormal( ia, ib, ic );
 
-          }
+					}
 
-          if (ua !== undefined) {
+					if ( this.colors.length > 0 ) {
 
-            var uvLen = this.uvs.length;
+						this.addColor( ia, ib, ic );
 
-            ia = this.parseUVIndex(ua, uvLen);
-            ib = this.parseUVIndex(ub, uvLen);
-            ic = this.parseUVIndex(uc, uvLen);
+					}
 
-            if (d === undefined) {
+				},
 
-              this.addUV(ia, ib, ic);
+				addLineGeometry: function ( vertices, uvs ) {
 
-            } else {
+					this.object.geometry.type = 'Line';
 
-              id = this.parseUVIndex(ud, uvLen);
+					var vLen = this.vertices.length;
+					var uvLen = this.uvs.length;
 
-              this.addUV(ia, ib, id);
-              this.addUV(ib, ic, id);
+					for ( var vi = 0, l = vertices.length; vi < l; vi ++ ) {
 
-            }
+						this.addVertexLine( this.parseVertexIndex( vertices[ vi ], vLen ) );
 
-          }
+					}
 
-          if (na !== undefined) {
+					for ( var uvi = 0, l = uvs.length; uvi < l; uvi ++ ) {
 
-            // Normals are many times the same. If so, skip function call and parseInt.
-            var nLen = this.normals.length;
-            ia = this.parseNormalIndex(na, nLen);
+						this.addUVLine( this.parseUVIndex( uvs[ uvi ], uvLen ) );
 
-            ib = na === nb ? ia : this.parseNormalIndex(nb, nLen);
-            ic = na === nc ? ia : this.parseNormalIndex(nc, nLen);
+					}
 
-            if (d === undefined) {
+				}
 
-              this.addNormal(ia, ib, ic);
+			};
 
-            } else {
+			state.startObject( '', false );
 
-              id = this.parseNormalIndex(nd, nLen);
+			return state;
 
-              this.addNormal(ia, ib, id);
-              this.addNormal(ib, ic, id);
+		}
 
-            }
+		//
 
-          }
+		function OBJLoader( manager ) {
 
-        },
+			this.manager = ( manager !== undefined ) ? manager : THREE.DefaultLoadingManager;
 
-        addLineGeometry: function (vertices, uvs) {
+			this.materials = null;
 
-          this.object.geometry.type = 'Line';
+		}
 
-          var vLen = this.vertices.length;
-          var uvLen = this.uvs.length;
+		OBJLoader.prototype = {
 
-          for (var vi = 0, l = vertices.length; vi < l; vi++) {
+			constructor: OBJLoader,
 
-            this.addVertexLine(this.parseVertexIndex(vertices[vi], vLen));
+			load: function ( url, onLoad, onProgress, onError ) {
 
-          }
+				var scope = this;
 
-          for (var uvi = 0, l = uvs.length; uvi < l; uvi++) {
+				var loader = new THREE.FileLoader( scope.manager );
+				loader.setPath( this.path );
+				loader.load( url, function ( text ) {
 
-            this.addUVLine(this.parseUVIndex(uvs[uvi], uvLen));
+					onLoad( scope.parse( text ) );
 
-          }
+				}, onProgress, onError );
 
-        }
+			},
 
-      };
+			setPath: function ( value ) {
 
-      state.startObject('', false);
+				this.path = value;
 
-      return state;
+			},
 
-    },
+			setMaterials: function ( materials ) {
 
-    parse: function (text, debug) {
-      if (typeof(debug) === 'undefined') {
-        debug = true;
-      }
+				this.materials = materials;
 
-      if (debug) {
-        console.time('OBJLoader');
-      }
+				return this;
 
-      var state = this._createParserState();
+			},
 
-      if (text.indexOf('\r\n') !== - 1) {
+			parse: function ( text ) {
 
-        // This is faster than String.split with regex that splits on both
-        text = text.replace(/\r\n/g, '\n');
+				console.time( 'OBJLoader' );
 
-      }
+				var state = new ParserState();
 
-      if (text.indexOf('\\\n') !== - 1) {
+				if ( text.indexOf( '\r\n' ) !== - 1 ) {
 
-        // join lines separated by a line continuation character (\)
-        text = text.replace(/\\\n/g, '');
+					// This is faster than String.split with regex that splits on both
+					text = text.replace( /\r\n/g, '\n' );
 
-      }
+				}
 
-      var lines = text.split('\n');
-      var line = '', lineFirstChar = '', lineSecondChar = '';
-      var lineLength = 0;
-      var result = [];
+				if ( text.indexOf( '\\\n' ) !== - 1 ) {
 
-      // Faster to just trim left side of the line. Use if available.
-      var trimLeft = (typeof ''.trimLeft === 'function');
+					// join lines separated by a line continuation character (\)
+					text = text.replace( /\\\n/g, '' );
 
-      for (var i = 0, l = lines.length; i < l; i++) {
+				}
 
-        line = lines[i];
+				var lines = text.split( '\n' );
+				var line = '', lineFirstChar = '';
+				var lineLength = 0;
+				var result = [];
 
-        line = trimLeft ? line.trimLeft() : line.trim();
+				// Faster to just trim left side of the line. Use if available.
+				var trimLeft = ( typeof ''.trimLeft === 'function' );
 
-        lineLength = line.length;
+				for ( var i = 0, l = lines.length; i < l; i ++ ) {
 
-        if (lineLength === 0) continue;
+					line = lines[ i ];
 
-        lineFirstChar = line.charAt(0);
+					line = trimLeft ? line.trimLeft() : line.trim();
 
-        // @todo invoke passed in handler if any
-        if (lineFirstChar === '#') continue;
+					lineLength = line.length;
 
-        if (lineFirstChar === 'v') {
+					if ( lineLength === 0 ) continue;
 
-          lineSecondChar = line.charAt(1);
+					lineFirstChar = line.charAt( 0 );
 
-          if (lineSecondChar === ' ' && (result = this.regexp.vertex_pattern.exec(line)) !== null) {
+					// @todo invoke passed in handler if any
+					if ( lineFirstChar === '#' ) continue;
 
-            // 0                  1      2      3
-            // ["v 1.0 2.0 3.0", "1.0", "2.0", "3.0"]
+					if ( lineFirstChar === 'v' ) {
 
-            state.vertices.push(
-              parseFloat(result[1]),
-              parseFloat(result[2]),
-              parseFloat(result[3])
-            );
+						var data = line.split( /\s+/ );
 
-          } else if (lineSecondChar === 'n' && (result = this.regexp.normal_pattern.exec(line)) !== null) {
+						switch ( data[ 0 ] ) {
 
-            // 0                   1      2      3
-            // ["vn 1.0 2.0 3.0", "1.0", "2.0", "3.0"]
+							case 'v':
+								state.vertices.push(
+									parseFloat( data[ 1 ] ),
+									parseFloat( data[ 2 ] ),
+									parseFloat( data[ 3 ] )
+								);
+								if ( data.length === 8 ) {
 
-            state.normals.push(
-              parseFloat(result[1]),
-              parseFloat(result[2]),
-              parseFloat(result[3])
-            );
+									state.colors.push(
+										parseFloat( data[ 4 ] ),
+										parseFloat( data[ 5 ] ),
+										parseFloat( data[ 6 ] )
 
-          } else if (lineSecondChar === 't' && (result = this.regexp.uv_pattern.exec(line)) !== null) {
+									);
 
-            // 0               1      2
-            // ["vt 0.1 0.2", "0.1", "0.2"]
+								}
+								break;
+							case 'vn':
+								state.normals.push(
+									parseFloat( data[ 1 ] ),
+									parseFloat( data[ 2 ] ),
+									parseFloat( data[ 3 ] )
+								);
+								break;
+							case 'vt':
+								state.uvs.push(
+									parseFloat( data[ 1 ] ),
+									parseFloat( data[ 2 ] )
+								);
+								break;
 
-            state.uvs.push(
-              parseFloat(result[1]),
-              parseFloat(result[2])
-            );
+						}
 
-          } else {
+					} else if ( lineFirstChar === 'f' ) {
 
-            this.onError("Unexpected vertex/normal/uv line: '" + line + "'");
+						var lineData = line.substr( 1 ).trim();
+						var vertexData = lineData.split( /\s+/ );
+						var faceVertices = [];
 
-          }
+						// Parse the face vertex data into an easy to work with format
 
-        } else if (lineFirstChar === "f") {
+						for ( var j = 0, jl = vertexData.length; j < jl; j ++ ) {
 
-          if ((result = this.regexp.face_vertex_uv_normal.exec(line)) !== null) {
+							var vertex = vertexData[ j ];
 
-            // f vertex/uv/normal vertex/uv/normal vertex/uv/normal
-            // 0                        1    2    3    4    5    6    7    8    9   10         11         12
-            // ["f 1/1/1 2/2/2 3/3/3", "1", "1", "1", "2", "2", "2", "3", "3", "3", undefined, undefined, undefined]
+							if ( vertex.length > 0 ) {
 
-            state.addFace(
-              result[1], result[4], result[7], result[10],
-              result[2], result[5], result[8], result[11],
-              result[3], result[6], result[9], result[12]
-            );
+								var vertexParts = vertex.split( '/' );
+								faceVertices.push( vertexParts );
 
-          } else if ((result = this.regexp.face_vertex_uv.exec(line)) !== null) {
+							}
 
-            // f vertex/uv vertex/uv vertex/uv
-            // 0                  1    2    3    4    5    6   7          8
-            // ["f 1/1 2/2 3/3", "1", "1", "2", "2", "3", "3", undefined, undefined]
+						}
 
-            state.addFace(
-              result[1], result[3], result[5], result[7],
-              result[2], result[4], result[6], result[8]
-            );
+						// Draw an edge between the first vertex and all subsequent vertices to form an n-gon
 
-          } else if ((result = this.regexp.face_vertex_normal.exec(line)) !== null) {
+						var v1 = faceVertices[ 0 ];
 
-            // f vertex//normal vertex//normal vertex//normal
-            // 0                     1    2    3    4    5    6   7          8
-            // ["f 1//1 2//2 3//3", "1", "1", "2", "2", "3", "3", undefined, undefined]
+						for ( var j = 1, jl = faceVertices.length - 1; j < jl; j ++ ) {
 
-            state.addFace(
-              result[1], result[3], result[5], result[7],
-              undefined, undefined, undefined, undefined,
-              result[2], result[4], result[6], result[8]
-            );
+							var v2 = faceVertices[ j ];
+							var v3 = faceVertices[ j + 1 ];
 
-          } else if ((result = this.regexp.face_vertex.exec(line)) !== null) {
+							state.addFace(
+								v1[ 0 ], v2[ 0 ], v3[ 0 ],
+								v1[ 1 ], v2[ 1 ], v3[ 1 ],
+								v1[ 2 ], v2[ 2 ], v3[ 2 ]
+							);
 
-            // f vertex vertex vertex
-            // 0            1    2    3   4
-            // ["f 1 2 3", "1", "2", "3", undefined]
+						}
 
-            state.addFace(
-              result[1], result[2], result[3], result[4]
-            );
+					} else if ( lineFirstChar === 'l' ) {
 
-          } else {
+						var lineParts = line.substring( 1 ).trim().split( " " );
+						var lineVertices = [], lineUVs = [];
 
-            this.onError("Unexpected face line: '" + line + "'");
+						if ( line.indexOf( "/" ) === - 1 ) {
 
-          }
+							lineVertices = lineParts;
 
-        } else if (lineFirstChar === "l") {
+						} else {
 
-          var lineParts = line.substring(1).trim().split(" ");
-          var lineVertices = [], lineUVs = [];
+							for ( var li = 0, llen = lineParts.length; li < llen; li ++ ) {
 
-          if (line.indexOf("/") === - 1) {
+								var parts = lineParts[ li ].split( "/" );
 
-            lineVertices = lineParts;
+								if ( parts[ 0 ] !== "" ) lineVertices.push( parts[ 0 ] );
+								if ( parts[ 1 ] !== "" ) lineUVs.push( parts[ 1 ] );
 
-          } else {
+							}
 
-            for (var li = 0, llen = lineParts.length; li < llen; li++) {
+						}
+						state.addLineGeometry( lineVertices, lineUVs );
 
-              var parts = lineParts[li].split("/");
+					} else if ( ( result = object_pattern.exec( line ) ) !== null ) {
 
-              if (parts[0] !== "") lineVertices.push(parts[0]);
-              if (parts[1] !== "") lineUVs.push(parts[1]);
+						// o object_name
+						// or
+						// g group_name
 
-            }
+						// WORKAROUND: https://bugs.chromium.org/p/v8/issues/detail?id=2869
+						// var name = result[ 0 ].substr( 1 ).trim();
+						var name = ( " " + result[ 0 ].substr( 1 ).trim() ).substr( 1 );
 
-          }
-          state.addLineGeometry(lineVertices, lineUVs);
+						state.startObject( name );
 
-        } else if ((result = this.regexp.object_pattern.exec(line)) !== null) {
+					} else if ( material_use_pattern.test( line ) ) {
 
-          // o object_name
-          // or
-          // g group_name
+						// material
 
-          // WORKAROUND: https://bugs.chromium.org/p/v8/issues/detail?id=2869
-          // var name = result[ 0 ].substr( 1 ).trim();
-          var name = (" " + result[0].substr(1).trim()).substr(1);
+						state.object.startMaterial( line.substring( 7 ).trim(), state.materialLibraries );
 
-          state.startObject(name);
+					} else if ( material_library_pattern.test( line ) ) {
 
-        } else if (this.regexp.material_use_pattern.test(line)) {
+						// mtl file
 
-          // material
+						state.materialLibraries.push( line.substring( 7 ).trim() );
 
-          state.object.startMaterial(line.substring(7).trim(), state.materialLibraries);
+					} else if ( lineFirstChar === 's' ) {
 
-        } else if (this.regexp.material_library_pattern.test(line)) {
+						result = line.split( ' ' );
 
-          // mtl file
+						// smooth shading
 
-          state.materialLibraries.push(line.substring(7).trim());
+						// @todo Handle files that have varying smooth values for a set of faces inside one geometry,
+						// but does not define a usemtl for each face set.
+						// This should be detected and a dummy material created (later MultiMaterial and geometry groups).
+						// This requires some care to not create extra material on each smooth value for "normal" obj files.
+						// where explicit usemtl defines geometry groups.
+						// Example asset: examples/models/obj/cerberus/Cerberus.obj
 
-        } else if ((result = this.regexp.smoothing_pattern.exec(line)) !== null) {
+						/*
+						 * http://paulbourke.net/dataformats/obj/
+						 * or
+						 * http://www.cs.utah.edu/~boulos/cs3505/obj_spec.pdf
+						 *
+						 * From chapter "Grouping" Syntax explanation "s group_number":
+						 * "group_number is the smoothing group number. To turn off smoothing groups, use a value of 0 or off.
+						 * Polygonal elements use group numbers to put elements in different smoothing groups. For free-form
+						 * surfaces, smoothing groups are either turned on or off; there is no difference between values greater
+						 * than 0."
+						 */
+						if ( result.length > 1 ) {
 
-          // smooth shading
+							var value = result[ 1 ].trim().toLowerCase();
+							state.object.smooth = ( value !== '0' && value !== 'off' );
 
-          // @todo Handle files that have varying smooth values for a set of faces inside one geometry,
-          // but does not define a usemtl for each face set.
-          // This should be detected and a dummy material created (later MultiMaterial and geometry groups).
-          // This requires some care to not create extra material on each smooth value for "normal" obj files.
-          // where explicit usemtl defines geometry groups.
-          // Example asset: examples/models/obj/cerberus/Cerberus.obj
+						} else {
 
-          var value = result[1].trim().toLowerCase();
-          state.object.smooth = (value === '1' || value === 'on');
+							// ZBrush can produce "s" lines #11707
+							state.object.smooth = true;
 
-          var material = state.object.currentMaterial();
-          if (material) {
+						}
+						var material = state.object.currentMaterial();
+						if ( material ) material.smooth = state.object.smooth;
 
-            material.smooth = state.object.smooth;
+					} else {
 
-          }
+						// Handle null terminated files without exception
+						if ( line === '\0' ) continue;
 
-        } else {
+						throw new Error( 'THREE.OBJLoader: Unexpected line: "' + line + '"' );
 
-          // Handle null terminated files without exception
-          if (line === '\0') continue;
+					}
 
-          this.onError("Unexpected line: '" + line + "'");
+				}
 
-        }
+				state.finalize();
 
-      }
+				var container = new THREE.Group();
+				container.materialLibraries = [].concat( state.materialLibraries );
 
-      state.finalize();
+				for ( var i = 0, l = state.objects.length; i < l; i ++ ) {
 
-      var container = new THREE.Group();
-      container.materialLibraries = [].concat(state.materialLibraries);
+					var object = state.objects[ i ];
+					var geometry = object.geometry;
+					var materials = object.materials;
+					var isLine = ( geometry.type === 'Line' );
 
-      for (var i = 0, l = state.objects.length; i < l; i++) {
+					// Skip o/g line declarations that did not follow with any faces
+					if ( geometry.vertices.length === 0 ) continue;
 
-        var object = state.objects[i];
-        var geometry = object.geometry;
-        var materials = object.materials;
-        var isLine = (geometry.type === 'Line');
+					var buffergeometry = new THREE.BufferGeometry();
 
-        // Skip o/g line declarations that did not follow with any faces
-        if (geometry.vertices.length === 0) continue;
+					buffergeometry.addAttribute( 'position', new THREE.Float32BufferAttribute( geometry.vertices, 3 ) );
 
-        var buffergeometry = new THREE.BufferGeometry();
+					if ( geometry.normals.length > 0 ) {
 
-        buffergeometry.addAttribute('position', new THREE.BufferAttribute(new Float32Array(geometry.vertices), 3));
+						buffergeometry.addAttribute( 'normal', new THREE.Float32BufferAttribute( geometry.normals, 3 ) );
 
-        if (geometry.normals.length > 0) {
+					} else {
 
-          buffergeometry.addAttribute('normal', new THREE.BufferAttribute(new Float32Array(geometry.normals), 3));
+						buffergeometry.computeVertexNormals();
 
-        } else {
+					}
 
-          buffergeometry.computeVertexNormals();
+					if ( geometry.colors.length > 0 ) {
 
-        }
+						buffergeometry.addAttribute( 'color', new THREE.Float32BufferAttribute( geometry.colors, 3 ) );
 
-        if (geometry.uvs.length > 0) {
+					}
 
-          buffergeometry.addAttribute('uv', new THREE.BufferAttribute(new Float32Array(geometry.uvs), 2));
+					if ( geometry.uvs.length > 0 ) {
 
-        }
+						buffergeometry.addAttribute( 'uv', new THREE.Float32BufferAttribute( geometry.uvs, 2 ) );
 
-        // Create materials
+					}
 
-        var createdMaterials = [];
+					// Create materials
 
-        for (var mi = 0, miLen = materials.length; mi < miLen; mi++) {
+					var createdMaterials = [];
 
-          var sourceMaterial = materials[mi];
-          var material = undefined;
+					for ( var mi = 0, miLen = materials.length; mi < miLen; mi ++ ) {
 
-          if (this.materials !== null) {
+						var sourceMaterial = materials[ mi ];
+						var material = undefined;
 
-            material = this.materials.create(sourceMaterial.name);
+						if ( this.materials !== null ) {
 
-            // mtl etc. loaders probably can't create line materials correctly, copy properties to a line material.
-            if (isLine && material && !(material instanceof THREE.LineBasicMaterial)) {
+							material = this.materials.create( sourceMaterial.name );
 
-              var materialLine = new THREE.LineBasicMaterial();
-              materialLine.copy(material);
-              material = materialLine;
+							// mtl etc. loaders probably can't create line materials correctly, copy properties to a line material.
+							if ( isLine && material && ! ( material instanceof THREE.LineBasicMaterial ) ) {
 
-            }
+								var materialLine = new THREE.LineBasicMaterial();
+								materialLine.copy( material );
+								material = materialLine;
 
-          }
+							}
 
-          if (!material) {
+						}
 
-            material = (!isLine ? new THREE.MeshPhongMaterial() : new THREE.LineBasicMaterial());
-            material.name = sourceMaterial.name;
+						if ( ! material ) {
 
-          }
+							material = ( ! isLine ? new THREE.MeshPhongMaterial() : new THREE.LineBasicMaterial() );
+							material.name = sourceMaterial.name;
 
-          material.shading = sourceMaterial.smooth ? THREE.SmoothShading : THREE.FlatShading;
+						}
 
-          createdMaterials.push(material);
+						material.flatShading = sourceMaterial.smooth ? false : true;
 
-        }
+						createdMaterials.push( material );
 
-        // Create mesh
+					}
 
-        var mesh;
+					// Create mesh
 
-        if (createdMaterials.length > 1) {
+					var mesh;
 
-          for (var mi = 0, miLen = materials.length; mi < miLen; mi++) {
+					if ( createdMaterials.length > 1 ) {
 
-            var sourceMaterial = materials[mi];
-            buffergeometry.addGroup(sourceMaterial.groupStart, sourceMaterial.groupCount, mi);
+						for ( var mi = 0, miLen = materials.length; mi < miLen; mi ++ ) {
 
-          }
+							var sourceMaterial = materials[ mi ];
+							buffergeometry.addGroup( sourceMaterial.groupStart, sourceMaterial.groupCount, mi );
 
-          var multiMaterial = new THREE.MultiMaterial(createdMaterials);
-          mesh = (!isLine ? new THREE.Mesh(buffergeometry, multiMaterial) : new THREE.LineSegments(buffergeometry, multiMaterial));
+						}
 
-        } else {
+						mesh = ( ! isLine ? new THREE.Mesh( buffergeometry, createdMaterials ) : new THREE.LineSegments( buffergeometry, createdMaterials ) );
 
-          mesh = (!isLine ? new THREE.Mesh(buffergeometry, createdMaterials[0]) : new THREE.LineSegments(buffergeometry, createdMaterials[0]));
-        }
+					} else {
 
-        mesh.name = object.name;
+						mesh = ( ! isLine ? new THREE.Mesh( buffergeometry, createdMaterials[ 0 ] ) : new THREE.LineSegments( buffergeometry, createdMaterials[ 0 ] ) );
 
-        container.add(mesh);
+					}
 
-      }
+					mesh.name = object.name;
 
-      if (debug) {
-        console.timeEnd('OBJLoader');
-      }
+					container.add( mesh );
 
-      return container;
+				}
 
-    }
+				console.timeEnd( 'OBJLoader' );
 
-  };
+				return container;
+
+			}
+
+		};
+
+		return OBJLoader;
+
+	} )();
 };

--- a/source/index.js
+++ b/source/index.js
@@ -391,8 +391,6 @@ module.exports = function (THREE) {
 
 			parse: function ( text ) {
 
-				console.time( 'OBJLoader' );
-
 				var state = new ParserState();
 
 				if ( text.indexOf( '\r\n' ) !== - 1 ) {
@@ -709,8 +707,6 @@ module.exports = function (THREE) {
 					container.add( mesh );
 
 				}
-
-				console.timeEnd( 'OBJLoader' );
 
 				return container;
 


### PR DESCRIPTION
I noticed that there are two older unmerged PRs (#12, #15) having to do with updating the OBJ Loader. In the meantime, it's gotten updated again. This PR simply pulls in the latest OBJ loader from https://github.com/mrdoob/three.js/blob/8af1260742e400c1b63f9e77dc4c8214bb283ab2/examples/js/loaders/OBJLoader.js

This latest version eliminates the console warning:
>  three.module.js:43338 THREE.MeshPhongMaterial: .shading has been removed. Use the boolean .flatShading instead.
